### PR TITLE
feat: support query params

### DIFF
--- a/src/Core/Infrastructure/Http/Request/Route.php
+++ b/src/Core/Infrastructure/Http/Request/Route.php
@@ -4,16 +4,20 @@ declare(strict_types=1);
 
 namespace Phractico\Core\Infrastructure\Http\Request;
 
+use Psr\Http\Message\UriInterface;
+
 class Route
 {
     private function __construct(
         public readonly string $httpMethod,
         public readonly string $resource,
-    ) {
-    }
+    ) {}
 
-    public static function create(string $httpMethod, string $resource): self
+    public static function create(string $httpMethod, string|UriInterface $resource): self
     {
+        if ($resource instanceof UriInterface) {
+            $resource = $resource->getPath();
+        }
         return new self($httpMethod, $resource);
     }
 

--- a/src/Core/Infrastructure/Http/Request/RouteHandler.php
+++ b/src/Core/Infrastructure/Http/Request/RouteHandler.php
@@ -31,7 +31,7 @@ class RouteHandler
         RequestInterface $request
     ): ResponseInterface {
         $httpMethod = $request->getMethod();
-        $resource = $request->getRequestTarget();
+        $resource = $request->getUri();
         $route = Route::create($httpMethod, $resource);
 
         foreach (self::$stack as $controllerInstance => $controllerRouteMapping) {
@@ -40,7 +40,7 @@ class RouteHandler
                 if ($controllerRoute->match($route)) {
                     $controller = new $controllerInstance();
                     /** @var Response $controllerResponse */
-                    $controllerResponse = $controller->$controllerAction();
+                    $controllerResponse = $controller->$controllerAction($request);
                     return $controllerResponse->render();
                 }
             }

--- a/src/Core/Infrastructure/Http/Request/RouteHandler.php
+++ b/src/Core/Infrastructure/Http/Request/RouteHandler.php
@@ -40,7 +40,7 @@ class RouteHandler
                 if ($controllerRoute->match($route)) {
                     $controller = new $controllerInstance();
                     /** @var Response $controllerResponse */
-                    $controllerResponse = $controller->$controllerAction($request);
+                    $controllerResponse = $controller->$controllerAction();
                     return $controllerResponse->render();
                 }
             }

--- a/tests/Core/Infrastructure/Http/Request/RouteHandlerTest.php
+++ b/tests/Core/Infrastructure/Http/Request/RouteHandlerTest.php
@@ -6,7 +6,10 @@ use App\Tests\Helpers\API\Http\FakeController;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework\TestCase;
+use Phractico\Core\Infrastructure\Http\Request\HttpRequestInterceptor;
+use Phractico\Core\Infrastructure\Http\Request\RequestHandler;
 use Phractico\Core\Infrastructure\Http\Request\RouteHandler;
+use Psr\Http\Message\RequestInterface;
 
 class RouteHandlerTest extends TestCase
 {
@@ -55,6 +58,7 @@ class RouteHandlerTest extends TestCase
         $this->assertJson($responseBody);
         $this->assertEquals(json_encode(['message' => 'FakeController']), $responseBody);
     }
+
     public function testHandlerShouldBeAbleToAccessTheRequestObject(): void
     {
 
@@ -64,6 +68,15 @@ class RouteHandlerTest extends TestCase
 
         $requestUri = new Uri('/fakeWithRequestInterface?param=1&paramm=2');
         $request = new Request('POST', $requestUri);
+        $httpRequestInterceptor = new class($request) implements HttpRequestInterceptor {
+            public function __construct(private RequestInterface $request) {}
+            public function intercept(): RequestInterface
+            {
+                return $this->request;
+            }
+        };
+
+        RequestHandler::handle($httpRequestInterceptor);
         $response = RouteHandler::handle($request);
         $responseBody = $response->getBody()->getContents();
 

--- a/tests/Core/Infrastructure/Http/Request/RouteHandlerTest.php
+++ b/tests/Core/Infrastructure/Http/Request/RouteHandlerTest.php
@@ -4,6 +4,7 @@ namespace Phractico\Tests\Core\Infrastructure\Http\Request;
 
 use App\Tests\Helpers\API\Http\FakeController;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework\TestCase;
 use Phractico\Core\Infrastructure\Http\Request\RouteHandler;
 
@@ -36,5 +37,38 @@ class RouteHandlerTest extends TestCase
         $this->assertEquals(500, $response->getStatusCode());
         $this->assertJson($responseBody);
         $this->assertEquals(json_encode(['error' => 'Internal Server Error']), $responseBody);
+    }
+
+    public function testHandlerShouldMatchUrisWithQueryParams(): void
+    {
+
+        $fakeController = new FakeController();
+        $controllerMapping = [get_class($fakeController)];
+        RouteHandler::init($controllerMapping);
+
+        $requestUri = new Uri('/fake?param=1&paramm=2');
+        $request = new Request('POST', $requestUri);
+        $response = RouteHandler::handle($request);
+        $responseBody = $response->getBody()->getContents();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertJson($responseBody);
+        $this->assertEquals(json_encode(['message' => 'FakeController']), $responseBody);
+    }
+    public function testHandlerShouldBeAbleToAccessTheRequestObject(): void
+    {
+
+        $fakeController = new FakeController();
+        $controllerMapping = [get_class($fakeController)];
+        RouteHandler::init($controllerMapping);
+
+        $requestUri = new Uri('/fakeWithRequestInterface?param=1&paramm=2');
+        $request = new Request('POST', $requestUri);
+        $response = RouteHandler::handle($request);
+        $responseBody = $response->getBody()->getContents();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertJson($responseBody);
+        $this->assertEquals(json_encode(['message' => 'FakeController with params: param=1&paramm=2']), $responseBody);
     }
 }

--- a/tests/Helpers/API/Http/FakeController.php
+++ b/tests/Helpers/API/Http/FakeController.php
@@ -9,16 +9,15 @@ use Phractico\Core\Infrastructure\Http\Request\Route;
 use Phractico\Core\Infrastructure\Http\Request\RouteCollection;
 use Phractico\Core\Infrastructure\Http\Response;
 use Phractico\Core\Infrastructure\Http\Response\JsonResponse;
+use Psr\Http\Message\RequestInterface;
 
 class FakeController implements Controller
 {
     public function routes(): RouteCollection
     {
         $collection = RouteCollection::for($this);
-        $collection->add(
-            Route::create('POST', '/fake'),
-            'fake'
-        );
+        $collection->add(Route::create('POST', '/fake'), 'fake');
+        $collection->add(Route::create('POST', '/fakeWithRequestInterface'), 'fakeWithRequestInterface');
         return $collection;
     }
 
@@ -27,6 +26,14 @@ class FakeController implements Controller
         return new JsonResponse(
             status: 200,
             body: ['message' => 'FakeController']
+        );
+    }
+
+    public function fakeWithRequestInterface(RequestInterface $request): Response
+    {
+        return new JsonResponse(
+            status: 200,
+            body: ['message' => 'FakeController with params: ' . $request->getUri()->getQuery()],
         );
     }
 }

--- a/tests/Helpers/API/Http/FakeController.php
+++ b/tests/Helpers/API/Http/FakeController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Helpers\API\Http;
 
 use Phractico\Core\Infrastructure\Http\Controller;
+use Phractico\Core\Infrastructure\Http\Request\RequestHandler;
 use Phractico\Core\Infrastructure\Http\Request\Route;
 use Phractico\Core\Infrastructure\Http\Request\RouteCollection;
 use Phractico\Core\Infrastructure\Http\Response;
@@ -29,8 +30,9 @@ class FakeController implements Controller
         );
     }
 
-    public function fakeWithRequestInterface(RequestInterface $request): Response
+    public function fakeWithRequestInterface(): Response
     {
+        $request = RequestHandler::getIncomingRequest();
         return new JsonResponse(
             status: 200,
             body: ['message' => 'FakeController with params: ' . $request->getUri()->getQuery()],


### PR DESCRIPTION
Add support for routes to match even with query params, as well as letting controllers receive their Requests as the first argument of their methods.

This lets us support query parameters.